### PR TITLE
ferriteviewer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Ferrite = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]

--- a/src/FerriteVis.jl
+++ b/src/FerriteVis.jl
@@ -9,6 +9,6 @@ include("utils.jl")
 include("makieplotting.jl")
 
 export MakiePlotter
-export warp_by_vector, warp_by_vector!, plot_grid, plot_grid!
+export ferriteviewer
 
 end

--- a/src/FerriteVis.jl
+++ b/src/FerriteVis.jl
@@ -2,6 +2,7 @@ module FerriteVis
 
 using Makie
 import Ferrite
+import LinearAlgebra
 
 abstract type AbstractPlotter end
 

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -153,9 +153,11 @@ function ferriteviewer(plotter::MakiePlotter{dim}) where dim
     menu_cm = Menu(fig, options=["cividis", "inferno", "thermal"],label="colormap", direction=:up)
     menu_field = Menu(fig, options=Ferrite.getfieldnames(plotter.dh))
     menu_deformation_field = Menu(fig, options=Ferrite.getfieldnames(plotter.dh))
+    menu_process = Menu(fig, options=[x₁,x₂,x₃,l2,l1])
     fig[1,3] = vgrid!(grid!(hcat(toggles,labels), tellheight=false),
                       Label(fig,"nodesize",width=nothing), markerslider,
                       Label(fig,"strokewidth",width=nothing), strokewidthslider,
+                      Label(fig,"processing function",width=nothing), menu_process,
                       Label(fig,"field",width=nothing), menu_field,
                       Label(fig, "deformation field",width=nothing),menu_deformation_field,
                       Label(fig, "colormap",width=nothing),menu_cm)
@@ -173,6 +175,10 @@ function ferriteviewer(plotter::MakiePlotter{dim}) where dim
     on(menu_deformation_field.selection) do field
         solutionp.deformation_field = field
         wireframep.deformation_field = field
+    end
+
+    on(menu_process.selection) do process_function
+        solutionp.process=process_function
     end
 
     return fig

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -55,7 +55,7 @@ end
     Attributes(
     plotnodes=true,
     strokewidth=2,
-    color=:black,
+    color=theme(scene, :linecolor),
     markersize=30,
     deformation_field=:default,
     visible=true,
@@ -159,6 +159,8 @@ function Makie.plot!(AR::Arrows{<:Tuple{<:MakiePlotter{dim}}}) where dim
         ps = [Point3f0(i) for i in eachrow(plotter.coords)]
         ns = lift(x->[Vec3f(i) for i in eachrow(x)],solution)
         lengths = lift((x,y,z)-> z===:default ? x.(y) : ones(length(y))*z, AR[:process], ns, AR[:color])
+    else
+        error("Arrows plots are only available in dim ≥ 2")
     end
     Makie.arrows!(AR, ps, ns, arrowsize=AR[:arrowsize], normalize=AR[:normalize], colormap=AR[:colormap], color=lengths, lengthscale=AR[:lengthscale])
 end

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -30,8 +30,8 @@ end
     Attributes(
     scale_plot=false,
     shading=false,
-    field=nothing,
-    deformation_field=nothing,
+    field=:default,
+    deformation_field=:default,
     process=postprocess,
     colormap=:viridis,
     transparent=false,
@@ -41,9 +41,9 @@ end
 
 function Makie.plot!(SP::SolutionPlot{<:Tuple{<:MakiePlotter}})
     plotter = SP[1][]
-    solution = lift((x,y) -> x===nothing ? reshape(dof_to_node(plotter.dh, plotter.u; field=1, process=y), Ferrite.getnnodes(plotter.dh.grid)) : reshape(dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=y), Ferrite.getnnodes(plotter.dh.grid)),SP[:field], SP[:process])
-    u_matrix = lift(x->x===nothing ? zeros(0,3) : dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=identity), SP[:deformation_field])
-    coords = lift((x,y,z) -> z===nothing ? plotter.coords : plotter.coords .+ (x .* y) , SP[:deformation_scale], u_matrix, SP[:deformation_field])
+    solution = lift((x,y) -> x===:default ? reshape(dof_to_node(plotter.dh, plotter.u; field=1, process=y), Ferrite.getnnodes(plotter.dh.grid)) : reshape(dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=y), Ferrite.getnnodes(plotter.dh.grid)),SP[:field], SP[:process])
+    u_matrix = lift(x->x===:default ? zeros(0,3) : dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=identity), SP[:deformation_field])
+    coords = lift((x,y,z) -> z===:default ? plotter.coords : plotter.coords .+ (x .* y) , SP[:deformation_scale], u_matrix, SP[:deformation_field])
     return Makie.mesh!(SP, coords, reshape_triangles(plotter), color=solution, shading=SP[:shading], scale_plot=SP[:scale_plot], colormap=SP[:colormap], transparent=SP[:transparent])
 end
 
@@ -53,7 +53,8 @@ end
     strokewidth=2,
     color=:black,
     markersize=30,
-    deformation_field=nothing,
+    deformation_field=:default,
+    visible=true,
     scale=1,
     )
 end
@@ -61,8 +62,8 @@ end
 function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
     plotter = WF[1][]
     physical_coords = [node.x[i] for node in Ferrite.getnodes(plotter.dh.grid), i in 1:dim] 
-    u_matrix = lift(x->x===nothing ? zeros(0,3) : dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=identity), WF[:deformation_field])
-    coords = lift((x,y,z) -> z===nothing ? physical_coords : physical_coords .+ (x .* y) , WF[:scale], u_matrix, WF[:deformation_field])
+    u_matrix = lift(x->x===:default ? zeros(0,3) : dof_to_node(plotter.dh, plotter.u; field=Ferrite.find_field(plotter.dh,x), process=identity), WF[:deformation_field])
+    coords = lift((x,y,z) -> z===:default ? physical_coords : physical_coords .+ (x .* y) , WF[:scale], u_matrix, WF[:deformation_field])
     lines = @lift begin
         dim > 2 ? (lines = Makie.Point3f0[]) : (lines = Makie.Point2f0[])
         for cell in Ferrite.getcells(plotter.dh.grid)
@@ -72,8 +73,8 @@ function Makie.plot!(WF::Wireframe{<:Tuple{<:MakiePlotter{dim}}}) where dim
         lines
     end
     nodes = lift((x,y)->x ? y : zeros(Float32,0,3),WF[:plotnodes], coords)
-    Makie.scatter!(WF,coords,markersize=WF[:markersize], color=WF[:color])
-    return Makie.linesegments!(WF,lines,color=WF[:color], linewidth=WF[:strokewidth])
+    Makie.scatter!(WF,coords,markersize=WF[:markersize], color=WF[:color], visible=WF[:visible])
+    return Makie.linesegments!(WF,lines,color=WF[:color], linewidth=WF[:strokewidth], visible=WF[:visible])
 end
 
 function Makie.plot!(WF::Wireframe{<:Tuple{<:Ferrite.AbstractGrid{dim}}}) where dim
@@ -91,7 +92,7 @@ end
 
 @recipe(Surface) do scene
     Attributes(
-    field = nothing,
+    field = :default,
     process = postprocess,
     scale_plot = false,
     shading = false,
@@ -101,7 +102,7 @@ end
  
 function Makie.plot!(SF::Surface{<:Tuple{<:MakiePlotter{2}}})
     plotter = SF[1][]
-    field = lift(x->x===nothing ? 1 : Ferrite.find_field(plotter.dh,x),SF[:field])
+    field = lift(x->x===:default ? 1 : Ferrite.find_field(plotter.dh,x),SF[:field])
     solution = lift((x,y)->reshape(dof_to_node(plotter.dh, plotter.u; field=x, process=y), Ferrite.getnnodes(plotter.dh.grid)),field,SF[:process])
     points = lift(x->[Makie.Point3f0(coord[1], coord[2], x[idx]) for (idx, coord) in enumerate(eachrow(plotter.coords))],solution)
     return Makie.mesh!(SF,points, reshape_triangles(plotter), color=solution, scale_plot=SF[:scale_plot], shading=SF[:shading], colormap=SF[:colormap])
@@ -111,8 +112,8 @@ end
     Attributes(
     arrowsize = 0.08,
     normalize = true,
-    field = nothing,
-    color = nothing,
+    field = :default,
+    color = :default,
     colormap = :viridis,
     process=postprocess,
     lengthscale = 1f0,
@@ -121,17 +122,36 @@ end
 
 function Makie.plot!(AR::Arrows{<:Tuple{<:MakiePlotter{dim}}}) where dim
     plotter = AR[1][]
-    field = lift(x->x===nothing ? 1 : Ferrite.find_field(plotter.dh,x),AR[:field])
+    field = lift(x->x===:default ? 1 : Ferrite.find_field(plotter.dh,x),AR[:field])
     @assert Ferrite.getfielddim(plotter.dh,field[]) > 1
     solution = lift(x->dof_to_node(plotter.dh, plotter.u; field=x, process=identity),field)
     if dim  == 2
         ps = [Point2f0(i) for i in eachrow(plotter.coords)]
         ns = lift(x->[Vec2f(i) for i in eachrow(x)],solution)
-        lengths = lift((x,y,z)-> z===nothing ? x.(y) : ones(length(y))*z, AR[:process], ns, AR[:color])
+        lengths = lift((x,y,z)-> z===:default ? x.(y) : ones(length(y))*z, AR[:process], ns, AR[:color])
     elseif dim  == 3
         ps = [Point3f0(i) for i in eachrow(plotter.coords)]
         ns = lift(x->[Vec3f(i) for i in eachrow(x)],solution)
-        lengths = lift((x,y,z)-> z===nothing ? x.(y) : ones(length(y))*z, AR[:process], ns, AR[:color])
+        lengths = lift((x,y,z)-> z===:default ? x.(y) : ones(length(y))*z, AR[:process], ns, AR[:color])
     end
     Makie.arrows!(AR, ps, ns, arrowsize=AR[:arrowsize], normalize=AR[:normalize], colormap=AR[:colormap], color=lengths, lengthscale=AR[:lengthscale])
+end
+
+function ferriteviewer(plotter)
+    fig = Figure()
+    ax = LScene(fig[1,1])
+    toggles = [Toggle(fig, active=active) for active in [true,true]]
+    labels = [Label(fig,label) for label in ["mesh", "deformation"]]
+    fig[1,3] = grid!(hcat(toggles,labels), tellheight=false)
+    solutionp = solutionplot!(plotter,colormap=:cividis,deformation_field=@lift $(toggles[2].active) ? :u : :default)
+    wireframep = wireframe!(plotter,markersize=50,strokewidth=1,deformation_field= @lift $(toggles[2].active) ? :u : :default)
+    connect!(wireframep.visible,toggles[1].active)
+    menu = Menu(fig[2,3], options=["cividis", "inferno", "thermal"])
+    cb = Colorbar(fig[1,2], colormap=:cividis)
+
+    on(menu.selection) do s
+        cb.colormap = s
+        solutionp.colormap = s
+    end
+    return fig
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,6 +10,11 @@ to_triangle(cell::Ferrite.AbstractCell{3,N,6}) where N = [Ferrite.vertices(cell)
                                                           Ferrite.vertices(cell)[[5,8,7]], Ferrite.vertices(cell)[[7,6,5]]]
 
 refshape(cell::Ferrite.AbstractCell) = typeof(Ferrite.default_interpolation(typeof(cell))).parameters[2]
+x₁(x) = x[1]
+x₂(x) = x[2]
+x₃(x) = x[3]
+l2(x) = LinearAlgebra.norm(x,2)
+l1(x) = LinearAlgebra.norm(x,1)
 
 function postprocess(node_values)
     dim = length(node_values)


### PR DESCRIPTION
added a default viewer with (I guess) all relevant options at this point, don't know if we want to add arrow plotting as well into it

2D case creates an `Axis` object, while the 3D case creates an `LScene`. Labeling for the mesh should be added as a switch at some point and maybe poweruser key bindings. As soon as we can handle time dependent data I'll add a time slider to go back and forth in time.
 `SolutionPlot` got now the new attribute `colorrange` which is called by `Colorbar` to automatically detect the bounds and thus, no need to recompute them.  `Wireframe`'s new attribute visible is used to easily switch on/off the mesh plot

![test](https://user-images.githubusercontent.com/27497290/139042822-85a4161d-5fbc-45e6-8949-74e22202a9be.gif)


