### PR TITLE
add one shot methods

### DIFF
--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -26,6 +26,12 @@ function Makie.convert_arguments(P::Type{<:Makie.Mesh}, plotter::MakiePlotter)
     return Makie.convert_arguments(P,plotter.coords,reshape_triangles(plotter))
 end
 
+const FerriteVisPlots = Union{Type{<:Wireframe},Type{<:SolutionPlot},Type{<:Arrows}}
+
+function Makie.convert_arguments(P::FerriteVisPlots, dh::Ferrite.AbstractDofHandler, u::Vector)
+    return (MakiePlotter(dh,u),)
+end
+
 @recipe(SolutionPlot) do scene
     Attributes(
     scale_plot=false,

--- a/src/makieplotting.jl
+++ b/src/makieplotting.jl
@@ -26,12 +26,6 @@ function Makie.convert_arguments(P::Type{<:Makie.Mesh}, plotter::MakiePlotter)
     return Makie.convert_arguments(P,plotter.coords,reshape_triangles(plotter))
 end
 
-const FerriteVisPlots = Union{Type{<:Wireframe},Type{<:SolutionPlot},Type{<:Arrows}}
-
-function Makie.convert_arguments(P::FerriteVisPlots, dh::Ferrite.AbstractDofHandler, u::Vector)
-    return (MakiePlotter(dh,u),)
-end
-
 @recipe(SolutionPlot) do scene
     Attributes(
     scale_plot=false,
@@ -232,4 +226,11 @@ function ferriteviewer(plotter::MakiePlotter{dim}) where dim
     end
 
     return fig
+end
+
+####### One Shot Methods ####### 
+const FerriteVisPlots = Union{Type{<:Wireframe},Type{<:SolutionPlot},Type{<:Arrows}}
+
+function Makie.convert_arguments(P::FerriteVisPlots, dh::Ferrite.AbstractDofHandler, u::Vector)
+    return (MakiePlotter(dh,u),)
 end


### PR DESCRIPTION
https://github.com/koehlerson/FerriteVis.jl/issues/17

adds for all plot types we support one shot methods, i.e.

```julia
wireframe(dh,u)
solutionplot(dh,u)
arrows(dh,u)
```

since we utilize `Makie.convert_arguments` all keywords and other nice stuff as e.g. `lift`able `Observables` is fully supported